### PR TITLE
Resolve Issues in Public Syncfusion Code Examples for WPF Spreadsheet Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,57 @@
-# How to capture the clipboard events of WPF SpreadSheet?
+# Capture the clipboard events of WPF SpreadSheet
 
 This sample illustrates how to capture the clipboard events of **WPF Spreadsheet**.
 
 You can capture the clipboard operations using the [PreviewKeyDown](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.control.previewkeydown?view=netframework-4.6) event in the [WPF Spreadsheet](https://www.syncfusion.com/spreadsheet-editor-sdk/wpf-spreadsheet-editor) (SfSpreadsheet) control, in which the copy/paste could be captured using the keyboard shortcuts.
 
-``` csharp
-protected override void OnAttached()
-{
-    //Event Subscription
-    this.AssociatedObject.PreviewKeyDown += AssociatedObject_PreviewKeyDown;
-}
- 
-//Event Customization
-private void AssociatedObject_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
-{
-    //To capture the clipboard(copy/paste) opeartions  
-    if ((Keyboard.IsKeyDown(Key.LeftCtrl)) && e.Key == Key.C)
-    {
-        MessageBox.Show("Control+C Pressed");
-    }
-    else if ((Keyboard.IsKeyDown(Key.LeftCtrl)) && e.Key == Key.V)
-    {
-        MessageBox.Show("Control+V Pressed");
-    }
-}
+## Prerequisites
+
+Before running this project, ensure you have the following installed:
+
+- **Visual Studio** 2019 or later
+- **.NET Framework** 4.6.2 or greater or **.NET Core** 8.0 or greater
+
+## Technologies Used
+
+- **WPF** (Windows Presentation Foundation) + **Syncfusion Spreadsheet**
+
+## Getting Started
+
+### 1. Clone the Repository
+
+Clone this repository to your local machine:
+
+```bash
+git clone https://github.com/SyncfusionExamples/capture-spreadsheet-events-wpf
+cd capture-spreadsheet-events-wpf
 ```
+
+### 2. Install Dependencies
+
+Install the required Syncfusion WPF Spreadsheet packages as dependencies:
+
+```bash
+dotnet add package Syncfusion.SfSpreadsheet.WPF
+dotnet add package Syncfusion.SfSpreadsheetHelper.WPF
+```
+
+Alternatively, you can restore packages using:
+
+```bash
+dotnet restore
+```
+
+### 3. Run the Application
+
+Run the project and test the feature directly from the WPF app:
+
+```bash
+dotnet run
+```
+
+Or open the solution in Visual Studio and press `F5` to build and run the application.
+
+## Resources
+
+- https://help.syncfusion.com/document-processing/excel/spreadsheet/wpf/getting-started
+- https://support.syncfusion.com/kb/article/11075/how-to-capture-the-clipboard-events-of-wpf-spreadsheet

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-**[View document in Syncfusion Flutter Knowledge base](https://www.syncfusion.com/kb/12644/how-to-capture-the-clipboard-events-of-wpf-spreadsheet)**
+# How to capture the clipboard events of WPF SpreadSheet?
+
+This sample illustrates how to capture the clipboard events of **WPF Spreadsheet**.
+
+You can apture the clipboard operations using the [PreviewKeyDown](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.control.previewkeydown?view=netframework-4.6) event in the [WPF Spreadsheet](https://www.syncfusion.com/spreadsheet-editor-sdk/wpf-spreadsheet-editor) (SfSpreadsheet) control, in which the copy/paste could be captured using the keyboard shortcuts.
+
+``` csharp
+protected override void OnAttached()
+{
+    //Event Subscription
+    this.AssociatedObject.PreviewKeyDown += AssociatedObject_PreviewKeyDown;
+}
+ 
+//Event Customization
+private void AssociatedObject_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+{
+    //To capture the clipboard(copy/paste) opeartions  
+    if ((Keyboard.IsKeyDown(Key.LeftCtrl)) && e.Key == Key.C)
+    {
+        MessageBox.Show("Control+C Pressed");
+    }
+    else if ((Keyboard.IsKeyDown(Key.LeftCtrl)) && e.Key == Key.V)
+    {
+        MessageBox.Show("Control+V Pressed");
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This sample illustrates how to capture the clipboard events of **WPF Spreadsheet**.
 
-You can apture the clipboard operations using the [PreviewKeyDown](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.control.previewkeydown?view=netframework-4.6) event in the [WPF Spreadsheet](https://www.syncfusion.com/spreadsheet-editor-sdk/wpf-spreadsheet-editor) (SfSpreadsheet) control, in which the copy/paste could be captured using the keyboard shortcuts.
+You can capture the clipboard operations using the [PreviewKeyDown](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.control.previewkeydown?view=netframework-4.6) event in the [WPF Spreadsheet](https://www.syncfusion.com/spreadsheet-editor-sdk/wpf-spreadsheet-editor) (SfSpreadsheet) control, in which the copy/paste could be captured using the keyboard shortcuts.
 
 ``` csharp
 protected override void OnAttached()


### PR DESCRIPTION
## Description: ##

Resolved the README issue requiring a minimum of 1,000 characters in the README file for this sample repository.

## Reference ##

**KB link:** https://support.syncfusion.com/kb/article/11075/how-to-capture-the-clipboard-events-of-wpf-spreadsheet

## Preview Image: ##

<img width="1054" height="539" alt="image" src="https://github.com/user-attachments/assets/df50dfaf-07d4-4358-8212-7e7ab8437405" />
<img width="1053" height="574" alt="image" src="https://github.com/user-attachments/assets/a2858b5e-a07f-4f17-9a7a-43b345c48a48" />
<img width="1045" height="131" alt="image" src="https://github.com/user-attachments/assets/dffb3106-e55d-4aa6-a318-62f59dc11d8f" />






